### PR TITLE
add repository config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.0.1",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/InnoBridge/llmbackendsdk.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "license": "InnoBridge",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
This pull request updates the `package.json` file to include repository information and configuration for publishing the package to the npm registry.

Key changes:

* Added a `repository` field specifying the Git repository URL.
* Added a `publishConfig` field to configure the package for public publishing on the npm registry.