### PR TITLE
migrate chatid and messageid from string to number to support uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/llmbackendsdk",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -44,7 +44,7 @@ const countChatsByUserId = async (userId: string, updatedAfter?: number): Promis
     return await databaseClient!.countChatsByUserId(userId, updatedAfter);
 };
 
-const addChat = async (chatId: number, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void> => {  
+const addChat = async (chatId: string, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void> => {  
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
@@ -73,7 +73,7 @@ const syncChats = async (userId: string, chats: Chat[], updatedAt?: number): Pro
         return;
     }
     const chatsToSync: Chat[] = [];
-    const chatsToDelete: number[] = [];
+    const chatsToDelete: string[] = [];
     
     const dbChats = await databaseClient?.getChatsByUserId(userId, updatedAt);
     const dbChatsMap = new Map(dbChats?.map(chat => [chat.chatId, chat]));
@@ -129,8 +129,8 @@ const countMessagesByUserId = async (userId: string, updatedAfter?: number): Pro
 };
 
 const addMessage = async (
-    messageId: number, 
-    chatId: number, 
+    messageId: string, 
+    chatId: string, 
     content: string, 
     role: string,
     createdAt: number,
@@ -142,7 +142,7 @@ const addMessage = async (
     await databaseClient?.addMessage(messageId, chatId, content, role, createdAt, imageUrl, prompt);
 };
 
-const getMessagesByChatIds = async (chatIds: number[]): Promise<any[]> => {
+const getMessagesByChatIds = async (chatIds: string[]): Promise<any[]> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
@@ -168,14 +168,14 @@ const addMessages = async (messages: Message[]): Promise<void> => {
     await databaseClient?.addMessages(messages);
 }
 
-const renameChat = async (chatId: number, title: string, updatedAt: number): Promise<void> => {
+const renameChat = async (chatId: string, title: string, updatedAt: number): Promise<void> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
     await databaseClient?.renameChat(chatId, title, updatedAt);
 };
 
-const deleteChat = async (chatId: number): Promise<void> => {
+const deleteChat = async (chatId: string): Promise<void> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }

--- a/src/models/storage/dto.ts
+++ b/src/models/storage/dto.ts
@@ -1,5 +1,5 @@
 interface Chat {
-    chatId: number;
+    chatId: string;
     title: string;
     userId: string;
     updatedAt: number;
@@ -7,8 +7,8 @@ interface Chat {
 };
 
 interface Message {
-    messageId: number;
-    chatId: number;
+    messageId: string;
+    chatId: string;
     content: string;
     role: string;
     createdAt: number;

--- a/src/storage/persistent/database_client.ts
+++ b/src/storage/persistent/database_client.ts
@@ -7,24 +7,24 @@ interface DatabaseClient {
     registerMigration(fromVersion: number, migrationFn: (client: PoolClient) => Promise<void>): void
     initializeDatabase(): Promise<void>;
     countChatsByUserId(userId: string, updatedAfter?: number): Promise<number>;
-    addChat(chatId: number, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void>;
+    addChat(chatId: string, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void>;
     addChats(chats: Chat[]): Promise<void>;
     getChatsByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number): Promise<Chat[]>;
-    syncChats(chatsToSync: Chat[], chatsToDelete: number[]): Promise<void>;
+    syncChats(chatsToSync: Chat[], chatsToDelete: string[]): Promise<void>;
     countMessagesByUserId(userId: string, updatedAfter?: number): Promise<number>;
     addMessage(
-        messageId: number, 
-        chatId: number, 
+        messageId: string, 
+        chatId: string, 
         content: string, 
         role: string,
         createdAt: number,
         imageUrl?: string, 
         prompt?: string): Promise<void>;
     addMessages(messages: Message[]): Promise<void>;
-    getMessagesByChatIds(chatIds: number[]): Promise<any[]>;
+    getMessagesByChatIds(chatIds: string[]): Promise<any[]>;
     getMessagesByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number): Promise<any[]>;
-    renameChat(chatId: number, title: string, updatedAt: number): Promise<void>;
-    deleteChat(chatId: number): Promise<void>;
+    renameChat(chatId: string, title: string, updatedAt: number): Promise<void>;
+    deleteChat(chatId: string): Promise<void>;
     shutdown(): Promise<void>;
 };
 

--- a/src/storage/persistent/postgres_client.ts
+++ b/src/storage/persistent/postgres_client.ts
@@ -103,7 +103,7 @@ class PostgresClient implements DatabaseClient {
         return parseInt(result.rows[0].total, 10);
     }
 
-    async addChat(chatId: number, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void> {
+    async addChat(chatId: string, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void> {
         await this.query(ADD_CHAT_QUERY, [chatId, userId, title, updatedAt, deletedAt || null]);
     }
 
@@ -155,7 +155,7 @@ class PostgresClient implements DatabaseClient {
      * @param chatsToDelete: list of chatIds that we use to delete messages by chatId
      * @returns void
      */
-    async syncChats(chatsToSync: Chat[], chatsToDelete: number[]): Promise<void> {
+    async syncChats(chatsToSync: Chat[], chatsToDelete: string[]): Promise<void> {
         if (chatsToSync.length === 0 && chatsToDelete.length === 0) {
             return;
         }
@@ -210,7 +210,7 @@ class PostgresClient implements DatabaseClient {
         return parseInt(result.rows[0].total, 10);
     };
 
-    async getMessagesByChatIds(chatIds: number[]): Promise<any[]> {
+    async getMessagesByChatIds(chatIds: string[]): Promise<any[]> {
         const result = await this.query(GET_MESSAGES_BY_CHAT_IDS_QUERY, [chatIds]);
         return result.rows;
     }
@@ -220,7 +220,7 @@ class PostgresClient implements DatabaseClient {
         return (await this.query(GET_MESSAGES_BY_USER_ID_QUERY, [userId, updatedAfter || null, limit, offset])).rows;
     }
 
-    async addMessage(messageId: number, chatId: number, content: string, role: string, createdAt: number, imageUrl?: string, prompt?: string): Promise<void> {
+    async addMessage(messageId: string, chatId: string, content: string, role: string, createdAt: number, imageUrl?: string, prompt?: string): Promise<void> {
         await this.query(ADD_MESSAGE_QUERY, [messageId, chatId, content, role, createdAt, imageUrl || null, prompt || null]);
     }
 
@@ -255,11 +255,11 @@ class PostgresClient implements DatabaseClient {
         await this.query(ADD_MESSAGES_QUERY, [messageIds, chatIds, contents, roles, createdAts, imageUrls, prompts]);
     }
 
-    async renameChat(chatId: number, title: string, updatedAt: number): Promise<void> {
+    async renameChat(chatId: string, title: string, updatedAt: number): Promise<void> {
         await this.query(RENAME_CHAT_QUERY, [title, updatedAt, chatId]);
     }
 
-    async deleteChat(chatId: number): Promise<void> {
+    async deleteChat(chatId: string): Promise<void> {
         await this.query(DELETE_CHAT_QUERY, [chatId]);
     }
 


### PR DESCRIPTION
This pull request introduces a significant change to the database schema and related code by transitioning `chatId` and `messageId` from `number` to `string` types. This impacts multiple files, including TypeScript interfaces, database queries, and client methods, to ensure consistency across the application. Additionally, the `package.json` version has been updated to `1.0.0`, marking a major release.

### Database Schema and Type Updates:
* Changed `chatId` and `messageId` from `number` to `string` in the `Chat` and `Message` interfaces in `src/models/storage/dto.ts`.
* Updated database schema to use `TEXT` instead of `INTEGER` for `id` fields in `chats` and `messages` tables. This includes updates to the primary key and foreign key constraints. [[1]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L15-R15) [[2]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L25-R26)
* Updated all database queries to reflect the type changes, including `ADD_CHATS_QUERY`, `UPSERT_CHATS_QUERY`, `DELETE_MESSAGES_BY_CHAT_IDS`, and others. [[1]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L73-R73) [[2]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L89-R89) [[3]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L102-R102) [[4]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L150-R151)

### API and Client Updates:
* Modified methods in `src/api/database.ts` to use `string` for `chatId` and `messageId` parameters, such as `addChat`, `syncChats`, `addMessage`, and `getMessagesByChatIds`. [[1]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L47-R47) [[2]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L76-R76) [[3]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L132-R133) [[4]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L145-R145) [[5]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L171-R178)
* Updated `DatabaseClient` interface and its implementation in `PostgresClient` to align with the new `string` types for `chatId` and `messageId`. [[1]](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L10-R27) [[2]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L106-R106) [[3]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L158-R158) [[4]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L223-R223) [[5]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L258-R262)

### Version Update:
* Bumped the `package.json` version from `0.1.2` to `1.0.0` to reflect the breaking changes introduced in this release.