### PR TITLE
add excludeDeleted flag  for filtering out deleted records 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/llmbackendsdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -37,18 +37,18 @@ const query = async (query: string, params?: any[]): Promise<any> => {
     return await databaseClient?.query(query, params);
 };
 
-const countChatsByUserId = async (userId: string, updatedAfter?: number): Promise<number> => {
+const countChatsByUserId = async (userId: string, updatedAfter?: number, excludeDeleted?: boolean): Promise<number> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    return await databaseClient!.countChatsByUserId(userId, updatedAfter);
+    return await databaseClient!.countChatsByUserId(userId, updatedAfter, excludeDeleted);
 };
 
-const addChat = async (chatId: string, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void> => {  
+const addChat = async (chatId: string, title: string, userId: string, updatedAt: number, createdAt?: number, deletedAt?: number): Promise<void> => {  
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    await databaseClient?.addChat(chatId, title, userId, updatedAt, deletedAt);
+    await databaseClient?.addChat(chatId, title, userId, updatedAt, createdAt, deletedAt);
 };
 
 const addChats = async (chats: Chat[]): Promise<void> => {
@@ -58,11 +58,11 @@ const addChats = async (chats: Chat[]): Promise<void> => {
     await databaseClient?.addChats(chats);
 }
 
-const getChatsByUserId = async (userId: string, updatedAfter?: number, limit?: number, page?: number): Promise<Chat[]> => {
+const getChatsByUserId = async (userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Chat[]> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    return await databaseClient!.getChatsByUserId(userId, updatedAfter, limit, page);
+    return await databaseClient!.getChatsByUserId(userId, updatedAfter, limit, page, excludeDeleted);
 };
 
 const syncChats = async (userId: string, chats: Chat[], updatedAt?: number): Promise<void> => {
@@ -121,11 +121,11 @@ const syncChats = async (userId: string, chats: Chat[], updatedAt?: number): Pro
     await databaseClient?.syncChats(chatsToSync, chatsToDelete);
 }
 
-const countMessagesByUserId = async (userId: string, updatedAfter?: number): Promise<number> => {
+const countMessagesByUserId = async (userId: string, updatedAfter?: number, excludeDeleted?: boolean): Promise<number> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    return await databaseClient!.countMessagesByUserId(userId, updatedAfter);
+    return await databaseClient!.countMessagesByUserId(userId, updatedAfter, excludeDeleted);
 };
 
 const addMessage = async (
@@ -149,11 +149,11 @@ const getMessagesByChatIds = async (chatIds: string[]): Promise<any[]> => {
     return await databaseClient!.getMessagesByChatIds(chatIds);
 };
 
-const getMessagesByUserId = async (userId: string, updatedAfter?: number, limit?: number, page?: number): Promise<any[]> => {
+const getMessagesByUserId = async (userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<any[]> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    return await databaseClient!.getMessagesByUserId(userId, updatedAfter, limit, page);
+    return await databaseClient!.getMessagesByUserId(userId, updatedAfter, limit, page, excludeDeleted);
 };
 
 /**

--- a/src/models/storage/dto.ts
+++ b/src/models/storage/dto.ts
@@ -3,6 +3,7 @@ interface Chat {
     title: string;
     userId: string;
     updatedAt: number;
+    createdAt?: number;
     deletedAt?: number;
 };
 

--- a/src/storage/persistent/database_client.ts
+++ b/src/storage/persistent/database_client.ts
@@ -6,12 +6,12 @@ interface DatabaseClient {
     query(query: string, params?: any[]): Promise<any>;
     registerMigration(fromVersion: number, migrationFn: (client: PoolClient) => Promise<void>): void
     initializeDatabase(): Promise<void>;
-    countChatsByUserId(userId: string, updatedAfter?: number): Promise<number>;
-    addChat(chatId: string, title: string, userId: string, updatedAt: number, deletedAt?: number): Promise<void>;
+    countChatsByUserId(userId: string, updatedAfter?: number, excludeDeleted?: boolean): Promise<number>;
+    addChat(chatId: string, title: string, userId: string, updatedAt: number, createdAt?:number, deletedAt?: number): Promise<void>;
     addChats(chats: Chat[]): Promise<void>;
-    getChatsByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number): Promise<Chat[]>;
+    getChatsByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Chat[]>;
     syncChats(chatsToSync: Chat[], chatsToDelete: string[]): Promise<void>;
-    countMessagesByUserId(userId: string, updatedAfter?: number): Promise<number>;
+    countMessagesByUserId(userId: string, updatedAfter?: number, excludeDeleted?: boolean): Promise<number>;
     addMessage(
         messageId: string, 
         chatId: string, 
@@ -22,7 +22,7 @@ interface DatabaseClient {
         prompt?: string): Promise<void>;
     addMessages(messages: Message[]): Promise<void>;
     getMessagesByChatIds(chatIds: string[]): Promise<any[]>;
-    getMessagesByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number): Promise<any[]>;
+    getMessagesByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<any[]>;
     renameChat(chatId: string, title: string, updatedAt: number): Promise<void>;
     deleteChat(chatId: string): Promise<void>;
     shutdown(): Promise<void>;


### PR DESCRIPTION
This pull request introduces enhancements to the database API by adding support for filtering out deleted records and tracking creation timestamps for chats. It updates multiple methods, interfaces, and queries to accommodate these changes.

### Database API Enhancements:

* **Support for Excluding Deleted Records**:
  - Updated methods in `src/api/database.ts` to include an `excludeDeleted` parameter for filtering out deleted chats and messages. (`countChatsByUserId`, `getChatsByUserId`, `countMessagesByUserId`, `getMessagesByUserId`) [[1]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L40-R51) [[2]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L61-R65) [[3]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L124-R128) [[4]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L152-R156)
  - Modified the `DatabaseClient` interface and its implementation in `PostgresClient` to reflect the new parameter. [[1]](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L9-R14) [[2]](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L25-R25) [[3]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L101-R119) [[4]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L208-R226) [[5]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L218-R237)
  - Adjusted SQL queries to conditionally exclude deleted records based on the `excludeDeleted` flag. (`COUNT_CHATS_BY_USER_ID_QUERY`, `GET_CHATS_BY_USER_ID_QUERY`, `COUNT_MESSAGES_BY_USER_ID_QUERY`, `GET_MESSAGES_BY_USER_ID_QUERY`) [[1]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L48-R108) [[2]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L121-R140) [[3]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R155-R158)

* **Tracking Chat Creation Timestamps**:
  - Added an optional `createdAt` field to the `Chat` interface in `src/models/storage/dto.ts`.
  - Updated methods in `src/api/database.ts` and the `DatabaseClient` interface to handle the `createdAt` field. (`addChat`, `addChats`, `syncChats`) [[1]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L40-R51) [[2]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L61-R65) [[3]](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L9-R14) [[4]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07R131-R155) [[5]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07R189-R205)
  - Adjusted SQL queries to store and upsert the `createdAt` field, defaulting to the current timestamp if not provided. (`ADD_CHAT_QUERY`, `ADD_CHATS_QUERY`, `UPSERT_CHATS_QUERY`) [[1]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L48-R108) [[2]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436L121-R140)

### Other Updates:

* **Version Increment**:
  - Updated the `package.json` version from `1.0.0` to `1.0.1`.