### PR TITLE
get messages api return message dto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/llmbackendsdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/storage/persistent/database_client.ts
+++ b/src/storage/persistent/database_client.ts
@@ -21,8 +21,8 @@ interface DatabaseClient {
         imageUrl?: string, 
         prompt?: string): Promise<void>;
     addMessages(messages: Message[]): Promise<void>;
-    getMessagesByChatIds(chatIds: string[]): Promise<any[]>;
-    getMessagesByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<any[]>;
+    getMessagesByChatIds(chatIds: string[]): Promise<Message[]>;
+    getMessagesByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Message[]>;
     renameChat(chatId: string, title: string, updatedAt: number): Promise<void>;
     deleteChat(chatId: string): Promise<void>;
     shutdown(): Promise<void>;

--- a/src/storage/persistent/postgres_client.ts
+++ b/src/storage/persistent/postgres_client.ts
@@ -227,14 +227,37 @@ class PostgresClient implements DatabaseClient {
         return parseInt(result.rows[0].total, 10);
     };
 
-    async getMessagesByChatIds(chatIds: string[]): Promise<any[]> {
+    async getMessagesByChatIds(chatIds: string[]): Promise<Message[]> {
         const result = await this.query(GET_MESSAGES_BY_CHAT_IDS_QUERY, [chatIds]);
-        return result.rows;
-    }
+        return result.rows.map((message: any) => {
+            const messageObject: any = {
+                messageId: message.id,
+                chatId: message.chat_id,
+                content: message.content,
+                role: message.role,
+                createdAt: message.created_at ? Date.parse(message.created_at.toISOString()) : null,
+                imageUrl: message.image_url || null,
+                prompt: message.prompt || null
+            };
+            return messageObject as Message;
+        });
+    };
 
-    async getMessagesByUserId(userId: string, updatedAfter?: number, limit: number = 20, page: number = 0, excludeDeleted: boolean = false): Promise<any[]> {
+    async getMessagesByUserId(userId: string, updatedAfter?: number, limit: number = 20, page: number = 0, excludeDeleted: boolean = false): Promise<Message[]> {
         const offset = page * limit;
-        return (await this.query(GET_MESSAGES_BY_USER_ID_QUERY, [userId, updatedAfter || null, limit, offset, excludeDeleted])).rows;
+        const result =  await this.query(GET_MESSAGES_BY_USER_ID_QUERY, [userId, updatedAfter || null, limit, offset, excludeDeleted]);
+        return result.rows.map((message: any) => {
+            const messageObject: any = {
+                messageId: message.id,
+                chatId: message.chat_id,
+                content: message.content,
+                role: message.role,
+                createdAt: message.created_at ? Date.parse(message.created_at.toISOString()) : null,
+                imageUrl: message.image_url || null,
+                prompt: message.prompt || null
+            };
+            return messageObject as Message;
+        });
     }
 
     async addMessage(messageId: string, chatId: string, content: string, role: string, createdAt: number, imageUrl?: string, prompt?: string): Promise<void> {


### PR DESCRIPTION
This pull request introduces several changes aimed at improving type safety and ensuring consistent data handling in the database client implementation. The most significant updates include modifying method return types in the `DatabaseClient` interface to use the `Message` type and updating the corresponding implementations in `PostgresClient` to map database rows to `Message` objects.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the library version from `1.0.1` to `1.0.2` to reflect the new changes.

### Database Client Enhancements:
* [`src/storage/persistent/database_client.ts`](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L24-R25): Updated the return types of `getMessagesByChatIds` and `getMessagesByUserId` in the `DatabaseClient` interface from `Promise<any[]>` to `Promise<Message[]>` for improved type safety.
* [`src/storage/persistent/postgres_client.ts`](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L230-R260): Refactored the `PostgresClient` implementation of `getMessagesByChatIds` and `getMessagesByUserId` to transform database rows into strongly-typed `Message` objects, ensuring consistent data structure and reducing reliance on `any`.