### PR TITLE
rename updatedAfter parameter to createdAfter for getMessagesByUserId api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/llmbackendsdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -149,11 +149,11 @@ const getMessagesByChatIds = async (chatIds: string[]): Promise<any[]> => {
     return await databaseClient!.getMessagesByChatIds(chatIds);
 };
 
-const getMessagesByUserId = async (userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<any[]> => {
+const getMessagesByUserId = async (userId: string, createdAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Message[]> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    return await databaseClient!.getMessagesByUserId(userId, updatedAfter, limit, page, excludeDeleted);
+    return await databaseClient!.getMessagesByUserId(userId, createdAfter, limit, page, excludeDeleted);
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import * as usage from '@/models/response/usage';
 import * as enums from '@/models/enums';
 import * as generateImageRequest from '@/models/request/generate_image_request';
 import * as imageResponse from '@/models/response/image_response';
-import * as sqllite from '@/models/sqllite';
 import * as databaseConfiguration from '@/models/storage/configuration';
 import * as databaseDto from '@/models/storage/dto';
 
@@ -35,7 +34,6 @@ export {
     enums,
     generateImageRequest,
     imageResponse,
-    sqllite,
     databaseConfiguration,
     databaseDto
 };

--- a/src/models/sqllite.ts
+++ b/src/models/sqllite.ts
@@ -1,8 +1,0 @@
-interface SQLiteRunResult {
-    changes: number;
-    lastInsertRowId: number;
-};
-
-export {
-    SQLiteRunResult
-};

--- a/src/storage/persistent/database_client.ts
+++ b/src/storage/persistent/database_client.ts
@@ -22,7 +22,7 @@ interface DatabaseClient {
         prompt?: string): Promise<void>;
     addMessages(messages: Message[]): Promise<void>;
     getMessagesByChatIds(chatIds: string[]): Promise<Message[]>;
-    getMessagesByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Message[]>;
+    getMessagesByUserId(userId: string, createdAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Message[]>;
     renameChat(chatId: string, title: string, updatedAt: number): Promise<void>;
     deleteChat(chatId: string): Promise<void>;
     shutdown(): Promise<void>;

--- a/src/storage/persistent/postgres_client.ts
+++ b/src/storage/persistent/postgres_client.ts
@@ -243,9 +243,9 @@ class PostgresClient implements DatabaseClient {
         });
     };
 
-    async getMessagesByUserId(userId: string, updatedAfter?: number, limit: number = 20, page: number = 0, excludeDeleted: boolean = false): Promise<Message[]> {
+    async getMessagesByUserId(userId: string, createdAfter?: number, limit: number = 20, page: number = 0, excludeDeleted: boolean = false): Promise<Message[]> {
         const offset = page * limit;
-        const result =  await this.query(GET_MESSAGES_BY_USER_ID_QUERY, [userId, updatedAfter || null, limit, offset, excludeDeleted]);
+        const result =  await this.query(GET_MESSAGES_BY_USER_ID_QUERY, [userId, createdAfter || null, limit, offset, excludeDeleted]);
         return result.rows.map((message: any) => {
             const messageObject: any = {
                 messageId: message.id,


### PR DESCRIPTION
This pull request includes updates to the `@innobridge/llmbackendsdk` library, focusing on versioning, database query improvements, and code cleanup. The most significant changes involve modifying database query parameters, removing unused code, and updating the library version.

### Database Query Improvements:
* Changed the parameter name from `updatedAfter` to `createdAfter` in the `getMessagesByUserId` function across multiple files (`src/api/database.ts`, `src/storage/persistent/database_client.ts`, `src/storage/persistent/postgres_client.ts`). This improves clarity by aligning the parameter name with its intended purpose. [[1]](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L152-R156) [[2]](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L25-R25) [[3]](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L246-R248)

### Code Cleanup:
* Removed the unused `sqllite` module from imports and exports in `src/index.ts`. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L17) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L38)
* Deleted the `SQLiteRunResult` interface from `src/models/sqllite.ts`, as it is no longer being used.

### Version Update:
* Updated the library version in `package.json` from `1.0.2` to `1.0.3`.