### PR TITLE
rename updatedAfter to createdAfter for countmessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/llmbackendsdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -121,11 +121,11 @@ const syncChats = async (userId: string, chats: Chat[], updatedAt?: number): Pro
     await databaseClient?.syncChats(chatsToSync, chatsToDelete);
 }
 
-const countMessagesByUserId = async (userId: string, updatedAfter?: number, excludeDeleted?: boolean): Promise<number> => {
+const countMessagesByUserId = async (userId: string, createdAfter?: number, excludeDeleted?: boolean): Promise<number> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
-    return await databaseClient!.countMessagesByUserId(userId, updatedAfter, excludeDeleted);
+    return await databaseClient!.countMessagesByUserId(userId, createdAfter, excludeDeleted);
 };
 
 const addMessage = async (

--- a/src/storage/persistent/database_client.ts
+++ b/src/storage/persistent/database_client.ts
@@ -11,7 +11,7 @@ interface DatabaseClient {
     addChats(chats: Chat[]): Promise<void>;
     getChatsByUserId(userId: string, updatedAfter?: number, limit?: number, page?: number, excludeDeleted?: boolean): Promise<Chat[]>;
     syncChats(chatsToSync: Chat[], chatsToDelete: string[]): Promise<void>;
-    countMessagesByUserId(userId: string, updatedAfter?: number, excludeDeleted?: boolean): Promise<number>;
+    countMessagesByUserId(userId: string, createdAfter?: number, excludeDeleted?: boolean): Promise<number>;
     addMessage(
         messageId: string, 
         chatId: string, 

--- a/src/storage/persistent/postgres_client.ts
+++ b/src/storage/persistent/postgres_client.ts
@@ -222,8 +222,8 @@ class PostgresClient implements DatabaseClient {
 
     }
 
-    async countMessagesByUserId(userId: string, updatedAfter?: number, excludeDeleted: boolean = false): Promise<number> {
-        const result = await this.query(COUNT_MESSAGES_BY_USER_ID_QUERY, [userId, updatedAfter || null, excludeDeleted]);
+    async countMessagesByUserId(userId: string, createdAfter?: number, excludeDeleted: boolean = false): Promise<number> {
+        const result = await this.query(COUNT_MESSAGES_BY_USER_ID_QUERY, [userId, createdAfter || null, excludeDeleted]);
         return parseInt(result.rows[0].total, 10);
     };
 


### PR DESCRIPTION
This pull request updates the `countMessagesByUserId` method across the codebase to use the parameter `createdAfter` instead of `updatedAfter`. This change ensures consistency in naming and aligns the method's purpose with its parameter.

### Parameter renaming for consistency:

* [`src/api/database.ts`](diffhunk://#diff-dbc3b8f4e90fb6d9454e57721a6c436034c41e312c1dfcca9bbd1e9ce76510b0L124-R128): Updated the `countMessagesByUserId` function to replace the `updatedAfter` parameter with `createdAfter`. The corresponding call to `databaseClient!.countMessagesByUserId` was also updated.
* [`src/storage/persistent/database_client.ts`](diffhunk://#diff-0ada2cc615240ab815a77710b9fbfe1719b38e71c9184bea5046ad0c4199f0e2L14-R14): Modified the `countMessagesByUserId` method in the `DatabaseClient` interface to use `createdAfter` instead of `updatedAfter`.
* [`src/storage/persistent/postgres_client.ts`](diffhunk://#diff-d1e0e3f140714bd7e353157dd5d39a08c27c8fd772eec0210555951e1ffc0f07L225-R226): Updated the `countMessagesByUserId` implementation in the `PostgresClient` class to replace `updatedAfter` with `createdAfter`, including its usage in the database query.